### PR TITLE
Fix build on Linux

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Nav from './Nav'
 import Footer from './Footer'
-import Seo from './Seo'
+import Seo from './seo'
 import { useStaticQuery, graphql } from 'gatsby'
 import './Layout.scss'
 

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import Layout from '../components/layout'
 import Container from 'react-bootstrap/Container'
-import SEO from '../components/Seo'
+import SEO from '../components/seo'
 
 export default () => (
   <Layout>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Layout from '../components/Layout'
+import Layout from '../components/layout'
 import Header from '../components/index/Header'
 import Overviews from '../components/index/Overviews'
 import Opportunities from '../components/index/Opportunities'


### PR DESCRIPTION
While Windows is case-insensitive, Linux on the other hand is case-sensitive.
This caused errors when building due to the layout.js and seo.js files not being found.